### PR TITLE
PM2 support

### DIFF
--- a/src/Channel/index.js
+++ b/src/Channel/index.js
@@ -380,7 +380,7 @@ class Channel {
    * @return {void}
    */
   clusterBroadcast (topic, payload) {
-    this.broadcast(topic, payload, [])
+    this.broadcastPayload(topic, payload, [])
   }
 }
 

--- a/src/ClusterHop/receiver.js
+++ b/src/ClusterHop/receiver.js
@@ -11,6 +11,7 @@
 
 const ChannelsManager = require('../Channel/Manager')
 const debug = require('debug')('adonis:websocket')
+const { deserialize } = require('./serializer')
 
 /**
  * Delivers the message from process to the channel
@@ -54,9 +55,9 @@ module.exports = function handleProcessMessage (message) {
    * Decoding the JSON message
    */
   try {
-    decoded = JSON.parse(message)
+    decoded = deserialize(message)
   } catch (error) {
-    debug('dropping packet, since not valid json')
+    debug('dropping packet, since it is not valid')
     return
   }
 

--- a/src/ClusterHop/sender.js
+++ b/src/ClusterHop/sender.js
@@ -9,10 +9,11 @@
  * file that was distributed with this source code.
 */
 const debug = require('debug')('adonis:websocket')
+const { serialize } = require('./serializer')
 
 module.exports = function (handle, topic, payload) {
   try {
-    process.send(JSON.stringify({ handle, topic, payload }))
+    process.send(serialize({ handle, topic, payload }))
   } catch (error) {
     debug('cluster.send error %o', error)
   }

--- a/src/ClusterHop/serializer/cluster.js
+++ b/src/ClusterHop/serializer/cluster.js
@@ -1,0 +1,38 @@
+'use strict'
+
+/**
+ * adonis-websocket
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+module.exports = {
+  /**
+   * Serialize data for sending as process message.
+   *
+   * @method serialize
+   *
+   * @param  {Object} data
+   *
+   * @return {String}
+   */
+  serialize (data) {
+    return JSON.stringify(data)
+  },
+
+  /**
+   * Deserialize recieved process message.
+   *
+   * @method deserialize
+   *
+   * @param  {String} message
+   *
+   * @return {Object}
+   */
+  deserialize (message) {
+    return JSON.parse(message)
+  }
+}

--- a/src/ClusterHop/serializer/index.js
+++ b/src/ClusterHop/serializer/index.js
@@ -1,0 +1,16 @@
+'use strict'
+
+/**
+ * adonis-websocket
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+if (typeof (process.env.pm_id) !== 'undefined') {
+  module.exports = require('./pm2')
+} else {
+  module.exports = require('./cluster')
+}

--- a/src/ClusterHop/serializer/pm2.js
+++ b/src/ClusterHop/serializer/pm2.js
@@ -1,0 +1,44 @@
+'use strict'
+
+/**
+ * adonis-websocket
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+const EVENT_TYPE = 'adonis:hop'
+
+module.exports = {
+  /**
+   * Serialize data for sending as process message.
+   *
+   * @method serialize
+   *
+   * @param  {Object} data
+   *
+   * @return {Object}
+   */
+  serialize (data) {
+    return { type: EVENT_TYPE, data }
+  },
+
+  /**
+   * Deserialize recieved process message.
+   *
+   * @method deserialize
+   *
+   * @param  {Object} message
+   *
+   * @return {Object}
+   */
+  deserialize (message) {
+    if (message.type === EVENT_TYPE) {
+      return message.data
+    }
+
+    throw new Error('Recieved message has different event type.')
+  }
+}

--- a/test/unit/cluster-receiver.spec.js
+++ b/test/unit/cluster-receiver.spec.js
@@ -22,7 +22,7 @@ test.group('Cluster Receiver', (group) => {
     clusterReceiver({ name: 'virk' })
 
     inspect.restore()
-    assert.equal(inspect.output[0].trim(), 'adonis:websocket dropping packet, since not valid json')
+    assert.equal(inspect.output[0].trim(), 'adonis:websocket dropping packet, since it is not valid')
   })
 
   test('ignore message when handle is missing', (assert) => {


### PR DESCRIPTION
## Proposed changes

Extract serializing messages for ClusterHop to serializer and add conditional implementation when
process is managed by pm2 so messages can be handled by message bus in PM2 module.

See issue #58 for detailed explanation.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-websocket/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Recieved and sent events need to have type when using PM2. I chose the name `adonis:hop`. This event type needs to be used when listening and emitting messages on PM2 message bus. I wrote a simple PM2 module, which can be used for broadcasting messages. You can install it as follows:

```
pm2 install ruby184/pm2-adonis
```

Also when I was testing if everything is working I found that `Channel.clusterBroadcast` is calling non exisitng method `Channel.broadcast`, which was renamed to `Channel.broadcastPayload` in commit https://github.com/adonisjs/adonis-websocket/commit/5a3464ca2eb4cf20724657745bba1c11e3cf2ebb. So I fixed it in this PR.

There is one more bug according to broadcasting to workers. When you use `Socket.emitTo` method, event is sent only to given IDs on current worker, but then broacasted and sent to ALL sockets for topic on other workers. I will send another PR to fix this issue.