### PR TITLE
Fix cluster broadcast when emitting only to specified ids

### DIFF
--- a/src/Channel/index.js
+++ b/src/Channel/index.js
@@ -308,11 +308,12 @@ class Channel {
        *
        * @param  {String}  event
        * @param  {Mixed}  data
+       * @param  {Array}  exceptIds
        *
        * @return {void}
        */
-      broadcast (event, data) {
-        this.socket.broadcastToAll(event, data)
+      broadcast (event, data, exceptIds = []) {
+        this.socket.broadcast(event, data, exceptIds)
       },
 
       /**
@@ -358,7 +359,7 @@ class Channel {
    *
    * @return {void}
    */
-  broadcastPayload (topic, payload, filterSockets = [], inverse) {
+  broadcastPayload (topic, payload, filterSockets = [], inverse = false) {
     this.getTopicSubscriptions(topic).forEach((socket) => {
       const socketIndex = filterSockets.indexOf(socket.id)
       const shouldSend = inverse ? socketIndex > -1 : socketIndex === -1
@@ -376,11 +377,12 @@ class Channel {
    *
    * @param  {String}         topic
    * @param  {String}         payload
+   * @param  {Object}         args
    *
    * @return {void}
    */
-  clusterBroadcast (topic, payload) {
-    this.broadcast(topic, payload, [])
+  clusterBroadcast (topic, payload, args = {}) {
+    this.broadcastPayload(topic, payload, args.ids, args.inverse)
   }
 }
 

--- a/src/ClusterHop/index.js
+++ b/src/ClusterHop/index.js
@@ -38,12 +38,13 @@ module.exports = {
    * @param  {String} handle
    * @param  {String} topic
    * @param  {Object} payload
+   * @param  {Object} args
    *
    * @return {void}
    */
-  send (handle, topic, payload) {
+  send (handle, topic, payload, args = {}) {
     if (cluster.isWorker) {
-      sender(handle, topic, payload)
+      sender(handle, topic, payload, args)
     }
   },
 

--- a/src/ClusterHop/receiver.js
+++ b/src/ClusterHop/receiver.js
@@ -20,10 +20,11 @@ const debug = require('debug')('adonis:websocket')
  * @param  {String}       handle
  * @param  {String}       topic
  * @param  {String}       payload
+ * @param  {Object}       args
  *
  * @return {void}
  */
-function deliverMessage (handle, topic, payload) {
+function deliverMessage (handle, topic, payload, args = {}) {
   if (handle === 'broadcast') {
     const channel = ChannelsManager.resolve(topic)
 
@@ -31,7 +32,7 @@ function deliverMessage (handle, topic, payload) {
       return debug('broadcast topic %s cannot be handled by any channel', topic)
     }
 
-    channel.clusterBroadcast(topic, payload)
+    channel.clusterBroadcast(topic, payload, args)
     return
   }
 
@@ -72,7 +73,7 @@ module.exports = function handleProcessMessage (message) {
    * Safely trying to deliver cluster messages
    */
   try {
-    deliverMessage(decoded.handle, decoded.topic, decoded.payload)
+    deliverMessage(decoded.handle, decoded.topic, decoded.payload, decoded.args)
   } catch (error) {
     debug('unable to process cluster message with error %o', error)
   }

--- a/src/ClusterHop/sender.js
+++ b/src/ClusterHop/sender.js
@@ -10,9 +10,9 @@
 */
 const debug = require('debug')('adonis:websocket')
 
-module.exports = function (handle, topic, payload) {
+module.exports = function (handle, topic, payload, args = {}) {
   try {
-    process.send(JSON.stringify({ handle, topic, payload }))
+    process.send(JSON.stringify({ handle, topic, payload, args }))
   } catch (error) {
     debug('cluster.send error %o', error)
   }

--- a/src/Socket/index.js
+++ b/src/Socket/index.js
@@ -123,10 +123,15 @@ class Socket {
    *
    * @param  {String}   event
    * @param  {Mixed}    data
+   * @param  {Array}    exceptIds
    *
    * @return {void}
    */
-  broadcast (event, data) {
+  broadcast (event, data, exceptIds = [this.id]) {
+    if (!Array.isArray(exceptIds)) {
+      throw GE.InvalidArgumentException.invalidParameter('broadcast expects 3rd parameter to be an array of socket ids', exceptIds)
+    }
+
     const packet = this.connection.makeEventPacket(this.topic, event, data)
 
     /**
@@ -137,8 +142,8 @@ class Socket {
       if (error) {
         return
       }
-      this.channel.broadcastPayload(this.topic, payload, [this.id])
-      ClusterHop.send('broadcast', this.topic, payload)
+      this.channel.broadcastPayload(this.topic, payload, exceptIds)
+      ClusterHop.send('broadcast', this.topic, payload, { ids: exceptIds })
     })
   }
 
@@ -196,7 +201,7 @@ class Socket {
         return
       }
       this.channel.broadcastPayload(this.topic, payload, ids, true)
-      ClusterHop.send('broadcast', this.topic, payload)
+      ClusterHop.send('broadcast', this.topic, payload, { ids, inverse: true })
     })
   }
 


### PR DESCRIPTION
## Proposed changes

When I was playing with the cluster to implement PM2 support I realized  that when using `Socket.emitTo` method, payload is sent to specified socket ids on current worker, but then broadcasted to other cluster workers and sent to all sockets - filtering of ids is not preserved. So I added these arguments to message broacasted by ClusterHop. Also I added an ability to specify ids ommited by broadcast. Examle:

```javascript
// broacast to all sockets except the current one (socket.id)
socket.broadcast('event', 'data')
// broadcast to all except sockets with ids "id1" and "id2"
socket.broadcast('event', 'data', ['id1', 'id2'])
// also when using channel
channel.topic('topic').broadcast('event', 'data', ['id1', 'id2'])
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-websocket/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I will add tests just tell me if you are OK with the changes made. Thank you.