### PR TITLE
Event acking

### DIFF
--- a/src/Socket/index.js
+++ b/src/Socket/index.js
@@ -251,7 +251,27 @@ class Socket {
   serverAck ({ id, data }) {
     if (this._acks.has(id)) {
       const ack = this._acks.get(id)
-      ack(data)
+      ack(null, data)
+      this._acks.delete(id)
+    } else {
+      debug('bad ack %s for %s topic', id, this.topic)
+    }
+  }
+
+  /**
+   * A new ack error received
+   *
+   * @method serverAckError
+   *
+   * @param  {Number}      options.id
+   * @param  {String}      options.message
+   *
+   * @return {void}
+   */
+  serverAckError ({ id, message }) {
+    if (this._acks.has(id)) {
+      const ack = this._acks.get(id)
+      ack(new Error(message))
       this._acks.delete(id)
     } else {
       debug('bad ack %s for %s topic', id, this.topic)

--- a/src/Socket/index.js
+++ b/src/Socket/index.js
@@ -26,6 +26,9 @@ const ClusterHop = require('../ClusterHop')
  */
 class Socket {
   constructor (topic, connection) {
+    this._acks = new Map()
+    this._nextAckId = 0
+
     this.channel = null
 
     /**
@@ -109,11 +112,18 @@ class Socket {
    * @param  {String}   event
    * @param  {Object}   data
    * @param  {Function} [ack]
+   * @param  {Function} [responseAck]
    *
    * @return {void}
    */
-  emit (event, data, ack) {
-    this.connection.sendEvent(this.topic, event, data, ack)
+  emit (event, data, ack, responseAck) {
+    let id
+    if (typeof (responseAck) === 'function') {
+      id = this._nextAckId++
+      this._acks.set(id, responseAck)
+    }
+
+    this.connection.sendEvent(this.topic, event, data, ack, id)
   }
 
   /**
@@ -222,10 +232,30 @@ class Socket {
    * @param  {String}      options.event
    * @param  {Mixed}       options.data
    *
-   * @return {void}
+   * @return {Promise}
    */
   serverMessage ({ event, data }) {
-    this.emitter.emit(event, data)
+    return this.emitter.emit(event, data)
+  }
+
+  /**
+   * A new ack received
+   *
+   * @method serverAck
+   *
+   * @param  {Number}      options.id
+   * @param  {Mixed}       options.data
+   *
+   * @return {void}
+   */
+  serverAck ({ id, data }) {
+    if (this._acks.has(id)) {
+      const ack = this._acks.get(id)
+      ack(data)
+      this._acks.delete(id)
+    } else {
+      debug('bad ack %s for %s topic', id, this.topic)
+    }
   }
 
   /**
@@ -241,9 +271,11 @@ class Socket {
       .emit('close', this)
       .then(() => {
         this.emitter.clearListeners()
+        this._acks.clear()
       })
       .catch(() => {
         this.emitter.clearListeners()
+        this._acks.clear()
       })
   }
 


### PR DESCRIPTION
## Proposed changes
Add event acking functionality for events (request - response flow). For details see feature request discussion https://github.com/adonisjs/adonis-websocket/issues/61. Changes are dependent on `adonis-websocket-packet` changes (new packet types and methods) - We first need to merge packet changes. PRs in other repositories as well as tests and documentation update will follow.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-websocket/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments
Server:
```javascript
socket.on('hello', (name) => {
  // resolved with no value
})
// this is the ack response when all callbacks return resolved promise
// because we take first non-undefined resolved value as response
socket.on('hello', (name) => {
  return 'resolved'
})
socket.on('hello', (name) => {
  throw new Error('rejected')
})
// in Ws controller
async onHello (name) {
  return 'resolved'
}
```
Client:
```javascript
socket.emit('hello', 'world', (err, data) => {
  if (err) {
    return console.log(err.message) // rejected
  }
  console.log(data) // 'resolved' if error was not thrown from one of event callbacks
})
```