### PR TITLE
fix(Connection): switched topic with no subscriptions exception to a debug message

### DIFF
--- a/src/Connection/index.js
+++ b/src/Connection/index.js
@@ -623,7 +623,7 @@ class Connection extends Emittery {
     }
 
     if (!this.hasSubscription(topic)) {
-      throw new Error(`Topic ${topic} doesn't have any active subscriptions`)
+      debug('Topic %s doesn\'t have any active subscriptions', topic)
     }
 
     return msp.eventPacket(topic, event, data)

--- a/test/unit/connection.spec.js
+++ b/test/unit/connection.spec.js
@@ -580,16 +580,16 @@ test.group('Connection', (group) => {
     helpers.startClient()
   })
 
-  test('return hard error when topic has no active subscriptions on a connection', (assert, done) => {
+  test('does not return hard error when topic has no active subscriptions on a connection', (assert, done) => {
     assert.plan(1)
 
     this.ws = helpers.startWsServer()
 
     this.ws.on('connection', (ws, req) => {
       const connection = new Connection(ws, req, JsonEncoder)
-      const fn = () => connection.sendEvent('chat')
+      const fn = () => connection.sendEvent('chat', 'message')
       done(() => {
-        assert.throw(fn, 'Topic chat doesn\'t have any active subscriptions')
+        assert.doesNotThrow(fn)
       })
     })
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

I've replaced the error inside Connection.makeEventPacket to a debug message as this was blocking broadcasts from being sent when a socket connection was closed. As far as I can tell, this does not cause any breaking changes.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-websocket/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This solution is based off of the investigation here: https://github.com/adonisjs/adonis-websocket/issues/63#issuecomment-417140481

Fixes #63